### PR TITLE
Dask support

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,10 @@
 Changelog
 =========
 
+Version 0.6.0rc2
+------------
+- Adds support for AnnData read as Dask arrays.
+
 Version 0.6.0rc1
 ------------
 - Adds support for `groups` and `exclude` arguments:

--- a/illico/asymptotic_wilcoxon.py
+++ b/illico/asymptotic_wilcoxon.py
@@ -1,3 +1,4 @@
+import threading
 from typing import Literal
 
 import anndata as ad
@@ -19,6 +20,7 @@ from illico.utils.ranking import (
     check_indices_sorted_per_parcel,
 )
 from illico.utils.registry import (
+    DaskArrayDataHandler,
     DataHandler,
     KernelDataFormat,
     Test,
@@ -30,6 +32,8 @@ from illico.utils.scanpy import format_illico_results_for_scanpy
 from illico.utils.sparse.csr import csr_sum_along_cols, csr_to_csc
 
 __all__ = ["asymptotic_wilcoxon"]
+
+LOADER_SEMAPHORE = threading.Semaphore(1)
 
 
 @delayed
@@ -57,6 +61,15 @@ def all_purpose_operator(
     the purpose of using a lazy format in the first place. For this specific scenario, a dedicated operator
     `ovo_lazy_csr_operator` has been implemented.
 
+    Note: the semaphore is only needed with DaskArrays to avoid oversubscription: if multiple threads call .compute() simultaneously,
+    the resulting footprint will be huge defeating the inital goal of using Dask. On the other hand, we don't want a sequential
+    setup were .compute and dispatcher() are called one after the other. The semaphore allows to have a concurrent setup equivalent to
+    having a thread loading .compute() in the background and queuing them in a queue of size 1, while other threads take the chunk as soon
+    as it's ready. Experiments showed that in the Dask setup, running 2 or 8 threads with the semaphore is the same runtime. Also, the time
+    saved by using 2 threads (compared to 1) is exactly the cumulated processing time (dispatcher run time), confirming that at any given
+    point in time, there is always a thread running .compute, and a thread running dispatcher, with zero idle time while ensuring limited footprint.
+    This simple semaphore reduced RAM footprint of a factor 2-3, for a small runtime increase (oversubscription is under-optimal anyways).
+
     """
     if group_container.encoded_ref_group == -1:
         test = Test.OVR
@@ -75,7 +88,12 @@ def all_purpose_operator(
     # Fetch the data from disk if in backed mode
     # The reason to be of not applying X[:, lb:ub] in all cases (backed or not) is that if the data is whole in RAM, the CSR chunking is optimized, and
     # if the data is not in RAM, CSR chunking is not implemented
-    fetched_data, bounds = data_handler.fetch_cols(lb, ub)
+    if isinstance(data_handler, DaskArrayDataHandler):
+        with LOADER_SEMAPHORE:  # Ensure that only one worker loads data at a time to avoid OOMs
+            fetched_data, bounds = data_handler.fetch_cols(lb, ub)
+    else:
+        fetched_data, bounds = data_handler.fetch_cols(lb, ub)
+
     # Convert to numba-compatible format
     X = data_handler.to_nb(fetched_data)
     # Call the dispatcher
@@ -175,6 +193,8 @@ def ovo_lazy_csr_operator(
     pre- computed sorted control and mean expression for this group, and performs OVO tests between this group and the
     reference group for all genes at once. This way, only one chunk of rows is loaded in RAM at once, which is much more
     memory-efficient than loading chunks of columns for CSR matrices.
+
+    Note: This operator is not suited for Dask arrays as loading scattered rows from a Dask Array is quite inefficient.
 
     """
     assert data_handler.kernel_data_format() == KernelDataFormat.CSR, "This operator is specific for CSR datasets."
@@ -366,10 +386,11 @@ def asymptotic_wilcoxon(
         logger.info(f"Using layer '{layer}' for differential expression.")
         X = adata.layers[layer]
     else:
-        if adata.isbacked and adata.isview:
+        if adata.isbacked and adata.is_view:
             logger.warning(
                 "adata.X is a view on a backed AnnData. The view will be loaded in memory. "
-                "If you want to subset the Anndata, consider using the `groups` or `exclude_from_ovr` argument."
+                "If you want to subset a lazy-loaded Anndata, consider using the `groups` or "
+                "`exclude_from_ovr` argument, or read your adata with Dask."
             )
         X = adata.X
     data_handler = data_handler_registry.get(X)
@@ -400,11 +421,19 @@ def asymptotic_wilcoxon(
         group_subset=groups,
         exclude=exclude_from_ovr,
     )
+    # TODO: fix min & max
     logger.info(
-        f"Found {group_container.counts.size} unique groups (min size: {group_container.counts.min()} cells; "
+        f"Found {group_container.n_selected_groups} unique groups (min size: {group_container.counts.min()} cells; "
         f"max size: {group_container.counts.max()} cells), with reference group: {reference}"
     )
     _, n_genes_total = X.shape
+
+    if isinstance(data_handler, DaskArrayDataHandler):
+        if n_threads > 2:
+            logger.info(
+                "Number of threads is limited when using Dask to avoid oversubscription. "
+                "Never more than one concurrent thread will be loading data."
+            )
 
     # Allocate the results dataframes
     cols = pd.Series(adata.var_names, name="feature", dtype=str)
@@ -418,6 +447,9 @@ def asymptotic_wilcoxon(
         with tqdm(total=n_tests, smoothing=0.0, unit="it", unit_scale=True, unit_divisor=1000) as pbar:
             if (
                 data_handler.is_lazy
+                and not isinstance(
+                    data_handler, DaskArrayDataHandler
+                )  # Dask is not suited for scattered row access, regardless if dense or CSR
                 and data_handler.kernel_data_format() is KernelDataFormat.CSR
                 and reference is not None
             ):

--- a/illico/utils/registry.py
+++ b/illico/utils/registry.py
@@ -3,6 +3,7 @@ from enum import Enum
 from typing import Any
 
 import anndata as ad
+import dask.array as da
 import h5py
 import numpy as np
 from numba import types
@@ -254,3 +255,59 @@ class H5pyBackedCSRDataHandler(CSRDataHandler):
     @property
     def is_lazy(self) -> bool:
         return True
+
+
+""" Dask Arrays. """
+
+
+class DaskArrayDataHandler(DataHandler):
+    def input_signature(self) -> tuple:
+        # Because this will be loaded by chunk, input type is necessarily contiguous
+        input_type = getattr(types, str(self.data.dtype.type))[:, ::1]
+        return input_type
+
+    def fetch_cols(self, lb: int, ub: int) -> tuple:
+        return self.data[:, lb:ub].compute(), (0, ub - lb)
+
+    def fetch_rows(self, indices: np.ndarray) -> tuple:
+        raise ValueError("Row fetching is only implemented for lazy CSR arrays.")
+
+    @property
+    def is_lazy(self) -> bool:
+        return True
+
+    def footprint(self) -> int:
+        return np.nan
+
+
+class DenseDaskArrayDataHandler(DaskArrayDataHandler, DenseDataHandler):
+    # Inherits everything from DaskArrayDataHandler and DenseDataHandler, no need to override anything
+    pass
+
+
+class CSCDaskArrayDataHandler(DaskArrayDataHandler, CSCDataHandler):
+    # Inherits everything from DaskArrayDataHandler and CSCDataHandler, no need to override anything
+    pass
+
+
+class CSRDaskArrayDataHandler(DaskArrayDataHandler, CSRDataHandler):
+    # Inherits almost everything from DaskArrayDataHandler and CSRDataHandler
+    def fetch_rows(self, indices: np.ndarray) -> tuple:
+        return self.data[indices, :].compute()
+
+
+# Because all dask arrays are of type da.Array, we need to inspect the meta attribute to determine the underlying array type and dispatch to the correct handler
+def _dask_handler_factory(x: da.Array) -> DataHandler:
+    meta = x._meta
+    if isinstance(meta, np.ndarray):
+        return DenseDaskArrayDataHandler(x)
+    elif isinstance(meta, (py_sparse.csr_matrix, py_sparse.csr_array)):
+        return CSRDaskArrayDataHandler(x)
+    elif isinstance(meta, (py_sparse.csc_matrix, py_sparse.csc_array)):
+        return CSCDaskArrayDataHandler(x)
+    else:
+        raise TypeError(f"Unsupported dask array backing type: {type(meta)}")
+
+
+data_handler_registry[da.Array] = _dask_handler_factory
+data_handler_registry[ad._core.views.DaskArrayView] = _dask_handler_factory

--- a/poetry.lock
+++ b/poetry.lock
@@ -402,6 +402,33 @@ files = [
 ]
 
 [[package]]
+name = "click"
+version = "8.4.1"
+description = "Composable command line interface toolkit"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "click-8.4.1-py3-none-any.whl", hash = "sha256:482be17c6991b8c19c5429a1e995d9b0efdbb63172824c41f99965dc0ade8ec2"},
+    {file = "click-8.4.1.tar.gz", hash = "sha256:918b5633eddf6b41c32d4f454bf0de810065c74e3f7dbf8ee5452f8be88d3e96"},
+]
+
+[package.dependencies]
+colorama = {version = "*", markers = "platform_system == \"Windows\""}
+
+[[package]]
+name = "cloudpickle"
+version = "3.1.2"
+description = "Pickler class to extend the standard pickle.Pickler functionality"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "cloudpickle-3.1.2-py3-none-any.whl", hash = "sha256:9acb47f6afd73f60dc1df93bb801b472f05ff42fa6c84167d25cb206be1fbf4a"},
+    {file = "cloudpickle-3.1.2.tar.gz", hash = "sha256:7fda9eb655c9c230dab534f1983763de5835249750e85fbcef43aaa30a9a2414"},
+]
+
+[[package]]
 name = "colorama"
 version = "0.4.6"
 description = "Cross-platform colored terminal text."
@@ -536,6 +563,36 @@ files = [
 [package.extras]
 docs = ["ipython", "matplotlib", "numpydoc", "sphinx"]
 tests = ["pytest", "pytest-cov", "pytest-xdist"]
+
+[[package]]
+name = "dask"
+version = "2026.6.0"
+description = "Parallel PyData with Task Scheduling"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "dask-2026.6.0-py3-none-any.whl", hash = "sha256:1539859071065dca379ca592ff76e911cd7965dc466da0040354ab466179189b"},
+    {file = "dask-2026.6.0.tar.gz", hash = "sha256:ae3436bd31ebce2be75edf952bd1fc687a1f11ec03fe8b1bec2903d222344a45"},
+]
+
+[package.dependencies]
+click = ">=8.1"
+cloudpickle = ">=3.0.0"
+fsspec = ">=2021.9.0"
+importlib_metadata = {version = ">=4.13.0", markers = "python_version < \"3.12\""}
+packaging = ">=20.0"
+partd = ">=1.4.0"
+pyyaml = ">=5.4.1"
+toolz = ">=0.12.0"
+
+[package.extras]
+array = ["numpy (>=1.24)"]
+complete = ["dask[array,dataframe,diagnostics,distributed]", "lz4 (>=4.3.2)"]
+dataframe = ["dask[array]", "pandas (>=2.0)", "pyarrow (>=16.0)"]
+diagnostics = ["bokeh (>=3.1.0)", "jinja2 (>=2.10.3)"]
+distributed = ["distributed (>=2026.6.0,<2026.6.1)"]
+test = ["pandas[test]", "pre-commit", "pytest", "pytest-cov", "pytest-mock", "pytest-rerunfailures", "pytest-timeout", "pytest-xdist"]
 
 [[package]]
 name = "debugpy"
@@ -761,6 +818,46 @@ unicode = ["unicodedata2 (>=17.0.0) ; python_version <= \"3.14\""]
 woff = ["brotli (>=1.0.1) ; platform_python_implementation == \"CPython\"", "brotlicffi (>=0.8.0) ; platform_python_implementation != \"CPython\"", "zopfli (>=0.1.4)"]
 
 [[package]]
+name = "fsspec"
+version = "2026.4.0"
+description = "File-system specification"
+optional = false
+python-versions = ">=3.10"
+groups = ["main"]
+files = [
+    {file = "fsspec-2026.4.0-py3-none-any.whl", hash = "sha256:11ef7bb35dab8a394fde6e608221d5cf3e8499401c249bebaeaad760a1a8dec2"},
+    {file = "fsspec-2026.4.0.tar.gz", hash = "sha256:301d8ac70ae90ef3ad05dcf94d6c3754a097f9b5fe4667d2787aa359ec7df7e4"},
+]
+
+[package.extras]
+abfs = ["adlfs"]
+adl = ["adlfs"]
+arrow = ["pyarrow (>=1)"]
+dask = ["dask", "distributed"]
+dev = ["pre-commit", "ruff (>=0.5)"]
+doc = ["numpydoc", "sphinx", "sphinx-design", "sphinx-rtd-theme", "yarl"]
+dropbox = ["dropbox", "dropboxdrivefs", "requests"]
+full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "dask", "distributed", "dropbox", "dropboxdrivefs", "fusepy", "gcsfs (>2024.2.0)", "libarchive-c", "ocifs", "panel", "paramiko", "pyarrow (>=1)", "pygit2", "requests", "s3fs (>2024.2.0)", "smbprotocol", "tqdm"]
+fuse = ["fusepy"]
+gcs = ["gcsfs (>2024.2.0)"]
+git = ["pygit2"]
+github = ["requests"]
+gs = ["gcsfs"]
+gui = ["panel"]
+hdfs = ["pyarrow (>=1)"]
+http = ["aiohttp (!=4.0.0a0,!=4.0.0a1)"]
+libarchive = ["libarchive-c"]
+oci = ["ocifs"]
+s3 = ["s3fs (>2024.2.0)"]
+sftp = ["paramiko"]
+smb = ["smbprotocol"]
+ssh = ["paramiko"]
+test = ["aiohttp (!=4.0.0a0,!=4.0.0a1)", "numpy", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "requests"]
+test-downstream = ["aiobotocore (>=2.5.4,<3.0.0)", "dask[dataframe,test]", "moto[server] (>4,<5)", "pytest-timeout", "xarray"]
+test-full = ["adlfs", "aiohttp (!=4.0.0a0,!=4.0.0a1)", "backports-zstd ; python_version < \"3.14\"", "cloudpickle", "dask", "distributed", "dropbox", "dropboxdrivefs", "fastparquet", "fusepy", "gcsfs", "jinja2", "kerchunk", "libarchive-c", "lz4", "notebook", "numpy", "ocifs", "pandas (<3.0.0)", "panel", "paramiko", "pyarrow", "pyarrow (>=1)", "pyftpdlib", "pygit2", "pytest", "pytest-asyncio (!=0.22.0)", "pytest-benchmark", "pytest-cov", "pytest-mock", "pytest-recording", "pytest-rerunfailures", "python-snappy", "requests", "smbprotocol", "tqdm", "urllib3", "zarr", "zstandard ; python_version < \"3.14\""]
+tqdm = ["tqdm"]
+
+[[package]]
 name = "furo"
 version = "2025.12.19"
 description = "A clean customisable Sphinx documentation theme."
@@ -945,11 +1042,12 @@ version = "8.7.1"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
     {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
 ]
+markers = {main = "python_version == \"3.11\""}
 
 [package.dependencies]
 zipp = ">=3.20"
@@ -1393,6 +1491,18 @@ files = [
     {file = "llvmlite-0.46.0-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:2e8cbfff7f6db0fa2c771ad24154e2a7e457c2444d7673e6de06b8b698c3b269"},
     {file = "llvmlite-0.46.0-cp314-cp314-win_amd64.whl", hash = "sha256:7821eda3ec1f18050f981819756631d60b6d7ab1a6cf806d9efefbe3f4082d61"},
     {file = "llvmlite-0.46.0.tar.gz", hash = "sha256:227c9fd6d09dce2783c18b754b7cd9d9b3b3515210c46acc2d3c5badd9870ceb"},
+]
+
+[[package]]
+name = "locket"
+version = "1.0.0"
+description = "File-based locks for Python on Linux and Windows"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+groups = ["main"]
+files = [
+    {file = "locket-1.0.0-py2.py3-none-any.whl", hash = "sha256:b6c819a722f7b6bd955b80781788e4a66a55628b858d347536b7e81325a3a5e3"},
+    {file = "locket-1.0.0.tar.gz", hash = "sha256:5c0d4c052a8bbbf750e056a8e65ccd309086f4f0f18a2eac306a8dfa4112a632"},
 ]
 
 [[package]]
@@ -2200,6 +2310,25 @@ files = [
 [package.extras]
 qa = ["flake8 (==5.0.4)", "types-setuptools (==67.2.0.1)", "zuban (==0.5.1)"]
 testing = ["docopt", "pytest"]
+
+[[package]]
+name = "partd"
+version = "1.4.2"
+description = "Appendable key-value storage"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "partd-1.4.2-py3-none-any.whl", hash = "sha256:978e4ac767ec4ba5b86c6eaa52e5a2a3bc748a2ca839e8cc798f1cc6ce6efb0f"},
+    {file = "partd-1.4.2.tar.gz", hash = "sha256:d022c33afbdc8405c226621b015e8067888173d85f7f5ecebb3cafed9a20f02c"},
+]
+
+[package.dependencies]
+locket = "*"
+toolz = "*"
+
+[package.extras]
+complete = ["blosc", "numpy (>=1.20.0)", "pandas (>=1.3)", "pyzmq"]
 
 [[package]]
 name = "patsy"
@@ -3793,6 +3922,18 @@ files = [
 ]
 
 [[package]]
+name = "toolz"
+version = "1.1.0"
+description = "List processing tools and functional utilities"
+optional = false
+python-versions = ">=3.9"
+groups = ["main"]
+files = [
+    {file = "toolz-1.1.0-py3-none-any.whl", hash = "sha256:15ccc861ac51c53696de0a5d6d4607f99c210739caf987b5d2054f3efed429d8"},
+    {file = "toolz-1.1.0.tar.gz", hash = "sha256:27a5c770d068c110d9ed9323f24f1543e83b2f300a687b7891c1a6d56b697b5b"},
+]
+
+[[package]]
 name = "tornado"
 version = "6.5.5"
 description = "Tornado is a Python web framework and asynchronous networking library, originally developed at FriendFeed."
@@ -4014,11 +4155,12 @@ version = "3.23.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
 optional = false
 python-versions = ">=3.9"
-groups = ["dev"]
+groups = ["main", "dev"]
 files = [
     {file = "zipp-3.23.0-py3-none-any.whl", hash = "sha256:071652d6115ed432f5ce1d34c336c0adfd6a884660d1e9712a256d3d3bd4b14e"},
     {file = "zipp-3.23.0.tar.gz", hash = "sha256:a07157588a12518c9d4034df3fbbee09c814741a33ff63c05fa29d26a2404166"},
 ]
+markers = {main = "python_version == \"3.11\""}
 
 [package.extras]
 check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
@@ -4031,4 +4173,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.11,<4.0"
-content-hash = "99b3d82396f0865d59dae8c5fdd52aee3ea11bcda19233f2e8d473ba830ceeca"
+content-hash = "06efa96354f19152146d365a3376c54b76dd884270b882301c6d4431e96a7812"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "illico"
-version = "0.6.0rc1"
+version = "0.6.0rc2"
 description = "Fast asymptotic mannwhitney-u test"
 authors = [
     {name = "remydubois",email = "remydubois14@gmail.com"}
@@ -15,6 +15,7 @@ dependencies = [
     "tqdm (>=4.67.1,<5.0.0)",
     "joblib (>=1.5.3,<2.0.0)",
     "loguru (>=0.7.3,<0.8.0)",
+    "dask (>=2026.6.0,<2027.0.0)",
 ]
 
 


### PR DESCRIPTION
This PR extends support to AnnData read as Dask arrays. `illico`'s parallelization scheme remains thread-based, and a `threading.Semaphore` ensures no resources oversubscription happens when the input is a Dask array. 